### PR TITLE
remove Allocator parameter from ULID.parse

### DIFF
--- a/base32.zig
+++ b/base32.zig
@@ -6,18 +6,21 @@ const range = @import("range").range;
 
 const alphabet = "0123456789ABCDEFGHJKMNPQRSTVWXYZ";
 
-pub fn decode(alloc: std.mem.Allocator, input: string) ![]const u5 {
-    var list = std.ArrayList(u5).init(alloc);
-    errdefer list.deinit();
+pub fn decode(comptime amount: usize, input: []const u8) [amount]u5 {
+    var list: [amount]u5 = undefined;
+
+    var index: usize = 0;
 
     for (input) |c| {
         for (alphabet) |d, i| {
             if (c == d) {
-                try list.append(@intCast(u5, i));
+                list[index] = @intCast(u5, i);
+                index += 1;
             }
         }
     }
-    return list.toOwnedSlice();
+
+    return list;
 }
 
 pub fn formatInt(comptime T: type, n: T, buf: []u8) void {

--- a/main.zig
+++ b/main.zig
@@ -26,7 +26,7 @@ pub fn main() anyerror!void {
 
 fn ensureFromTo(before: string) !void {
     const alloc = std.heap.page_allocator;
-    const ul = try ulid.ULID.fromString(alloc, before);
+    const ul = try ulid.ULID.parse(before);
     const after = try ul.toString(alloc);
     try std.testing.expectEqualStrings(before, after);
 }

--- a/ulid.zig
+++ b/ulid.zig
@@ -38,11 +38,15 @@ pub const ULID = struct {
 
     usingnamespace extras.StringerJsonStringifyMixin(@This());
 
-    pub fn parse(alloc: std.mem.Allocator, value: BaseType) !ULID {
+    pub fn parse(value: BaseType) !ULID {
         if (value.len != 26) return error.Ulid;
+
+        const decoded_timestamp = base32.decode(10, value[0..10]);
+        const decoded_randomnes = base32.decode(16, value[10..26]);
+
         return ULID{
-            .timestamp = std.math.cast(u48, try extras.sliceToInt(u50, u5, try base32.decode(alloc, value[0..10]))) orelse return error.Ulid,
-            .randomnes = try extras.sliceToInt(u80, u5, try base32.decode(alloc, value[10..26])),
+            .timestamp = std.math.cast(u48, try extras.sliceToInt(u50, u5, &decoded_timestamp)) orelse return error.Ulid,
+            .randomnes = try extras.sliceToInt(u80, u5, &decoded_randomnes),
         };
     }
 

--- a/zigmod.lock
+++ b/zigmod.lock
@@ -1,3 +1,3 @@
 2
-git https://github.com/nektro/zig-range commit-890ca308fe09b3d5c866d5cfb3b3d7a95dbf939f
-git https://github.com/nektro/zig-extras commit-86e312abea8012e39f868f1f2fbc72d6e28a466b
+git https://github.com/nektro/zig-extras commit-24fb8bc90898efa2f7c8fa094f9dab80d38ec55e
+git https://github.com/nektro/zig-range commit-4b2f12808aa09be4b27a163efc424dd4e0415992


### PR DESCRIPTION
if we already know that the length of an ULID is always 26 characters, why would we need the allocator for decoding it?

also fixes zig-ulid for latest zig changes (as `ArrayList.toOwnedSlice()` can return an error now)